### PR TITLE
Update the getRepresentativeHCard() method

### DIFF
--- a/src/BarnabyWalters/Mf2/Functions.php
+++ b/src/BarnabyWalters/Mf2/Functions.php
@@ -256,12 +256,14 @@ function getRepresentativeHCard(array $mfs, $url) {
 		}
 	}
 
-	$hCardsMatchingUrlPageUrl = findMicroformatsByCallable($hCards, function ($hCard) use ($url) {
-		return hasProp($hCard, 'url')
-			and count(array_filter($hCard['properties']['url'], function ($u) use ($url) {
-				return urlsMatch($u, $url);
-			})) > 0;
-	});
+	if (count($hCards) == 1) {
+		$hCardsMatchingUrlPageUrl = findMicroformatsByCallable($hCards, function ($hCard) use ($url) {
+			return hasProp($hCard, 'url')
+				and count(array_filter($hCard['properties']['url'], function ($u) use ($url) {
+					return urlsMatch($u, $url);
+				})) > 0;
+		});
+	}
 
 	if (count($hCardsMatchingUrlPageUrl) === 1) {
 		return $hCardsMatchingUrlPageUrl[0];

--- a/test/CleanerTest.php
+++ b/test/CleanerTest.php
@@ -433,7 +433,7 @@ class CleanerTest extends PHPUnit_Framework_TestCase {
 			[
 				'type' => ['h-card'],
 				'properties' => [
-					'url' => ['https://example.com'],
+					'url' => ['https://example.com/user'],
 					'name' => ['Second h-card']
 				]
 			]]

--- a/test/CleanerTest.php
+++ b/test/CleanerTest.php
@@ -418,6 +418,32 @@ class CleanerTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Test no representative h-card when *multiple* h-card with `url` == page URL method
+	 */
+	public function testGetRepresentativeHCardMultipleHCardUrlSourceMethod() {
+		$url = 'https://example.com';
+		$mfs = [
+			'items' => [[
+				'type' => ['h-card'],
+				'properties' => [
+					'url' => ['https://example.com'],
+					'name' => ['First h-card']
+				]
+			],
+			[
+				'type' => ['h-card'],
+				'properties' => [
+					'url' => ['https://example.com'],
+					'name' => ['Second h-card']
+				]
+			]]
+		];
+
+		$repHCard = getRepresentativeHCard($mfs, $url);
+		$this->assertNull($repHCard);
+	}
+
+	/**
 	 * The getRepresentativeHCard() method used to return other h-* roots.
 	 * Modified this previous test to ensure the h-entry is not returned
 	 * even when its `url` == `uid` == page URL
@@ -491,14 +517,14 @@ class CleanerTest extends PHPUnit_Framework_TestCase {
 				'type' => ['h-entry'],
 				'properties' => [
 					'url' => ['https://example.com'],
-					'name' => ['Incorrect h-card']
+					'name' => ['Not an h-card']
 				]
 			],
 			[
 				'type' => ['h-entry'],
 				'properties' => [
 					'url' => ['https://example.com'],
-					'name' => ['Another Incorrect h-card']
+					'name' => ['Also not an h-card']
 				]
 			]]
 		];


### PR DESCRIPTION
The `getRepresentativeHCard()` method was running the algorithm on any root h-*, not just h-card. It now only finds h-cards and the test coverage is updated accordingly.

I updated the `urlsMatch()` method so it matches URLs with empty path and /.

I fixed a couple mis-types: "pathname" with the parse_url and the duplicate `!array_key_exists($component, $u1)`.