### PR TITLE
Refactor getRepresentativeHCard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,23 +1,25 @@
 {
-    "name": "barnabywalters/mf-cleaner",
-    "description": "Cleans up microformats2 array structures",
-    "require": {},
-    "require-dev": {
-        "phpunit/phpunit": "*",
-				"php": ">=5.3"
-    },
-	  "autoload": {
-			"files": ["src/BarnabyWalters/Mf2/Functions.php"]
-		},
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Barnaby Walters",
-            "email": "barnaby@waterpigs.co.uk"
-        }
-    ],
-		"suggest": {
-			"mf2/mf2": "To parse microformats2 structures from (X)HTML"
-		},
-    "minimum-stability": "dev"
+  "name": "barnabywalters/mf-cleaner",
+  "description": "Cleans up microformats2 array structures",
+  "require": {},
+  "require-dev": {
+    "phpunit/phpunit": "*",
+    "php": ">=5.3"
+  },
+  "autoload": {
+    "files": [
+      "src/BarnabyWalters/Mf2/Functions.php"
+    ]
+  },
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Barnaby Walters",
+      "email": "barnaby@waterpigs.co.uk"
+    }
+  ],
+  "suggest": {
+    "mf2/mf2": "To parse microformats2 structures from (X)HTML"
+  },
+  "minimum-stability": "dev"
 }

--- a/test/CleanerTest.php
+++ b/test/CleanerTest.php
@@ -337,6 +337,72 @@ class CleanerTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Test anyUrlsMatch() method comparing arrays of URLs
+	 */
+	public function testAnyUrlsMatchParameter1() {
+		$this->expectException('InvalidArgumentException');
+
+		$array = [
+			'https://example.com/',
+		];
+
+		anyUrlsMatch('string', $array);
+	}
+
+	public function testAnyUrlsMatchParameter2() {
+		$this->expectException('InvalidArgumentException');
+
+		$array = [
+			'https://example.com/',
+		];
+
+		anyUrlsMatch($array, 'string');
+	}
+
+	public function testAnyUrlsMatchNoMatch() {
+		$array1 = [
+			'https://example.com/',
+		];
+
+		$array2 = [
+			'https://example.com/profile',
+		];
+
+		$this->assertFalse(anyUrlsMatch($array1, $array2));
+		$this->assertFalse(anyUrlsMatch($array2, $array1));
+	}
+
+	public function testAnyUrlsMatch1() {
+		$array1 = [
+			'https://example.com/',
+		];
+
+		$array2 = [
+			'https://example.com/',
+		];
+
+		$this->assertTrue(anyUrlsMatch($array1, $array2));
+		$this->assertTrue(anyUrlsMatch($array2, $array1));
+	}
+
+	public function testAnyUrlsMatch2() {
+		$array1 = [
+			'https://example.com/profile1',
+			'https://example.com/profile2',
+			'https://example.com/profile3',
+		];
+
+		$array2 = [
+			'https://example.com/profile3',
+			'https://example.com/profile2',
+			'https://example.com/profile5',
+		];
+
+		$this->assertTrue(anyUrlsMatch($array1, $array2));
+		$this->assertTrue(anyUrlsMatch($array2, $array1));
+	}
+
+	/**
 	 * Test the h-card `url` == `uid` == page URL method
 	 * Use the first h-card that meets the criteria
 	 */


### PR DESCRIPTION
Use `getPlaintext` and `getPlaintextArray` methods in this method instead of accessing the `$mfs['properties']` array directly. We ran into edge cases on indiewebify.me where `url` properties were nested microformats (https://github.com/indieweb/indiewebify-me/issues/99)

I tried to make the code easier to read, too. Used more guard clauses to return earlier and added `anyUrlsMatch()` method which takes two arrays of URLs and returns true if any of them match. I think the resulting code is easier to read than the `count() > array_filter() > closure` method.

I hope this isn't too bold of a change. Happy to make updates based on feedback.